### PR TITLE
Assign a CORS rule to the media bucket to allow NZSL properties to fetch images and videos

### DIFF
--- a/signbank/env-production/main.tf
+++ b/signbank/env-production/main.tf
@@ -110,6 +110,23 @@ resource "aws_s3_bucket_acl" "media" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_cors_configuration" "media" {
+  bucket = aws_s3_bucket.media.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = [
+      "http://localhost:3000",
+      "https://*.nzslshare.nz",
+      "https://*.nzsl.nz",
+      "https://nzsl-staging.herokuapp.com"
+    ]
+    expose_headers  = []
+    max_age_seconds = 3000
+  }
+}
+
 resource "aws_iam_user" "app" {
   name = "signbank-app-production"
   tags = var.default_tags


### PR DESCRIPTION
Some NZSL sites use requests that run into CORS restrictions to fetch images. This change sets a CORS policy on the bucket that allows GET requests from these known properties to the production media bucket. 

I considered allowing all origins, however decided not to do this to try and prevent people hotlinking to the images.