### PR TITLE
Provision access keys and OIDC role for dictionary export access

### DIFF
--- a/modules/github_oidc_role/README.md
+++ b/modules/github_oidc_role/README.md
@@ -1,0 +1,200 @@
+# `github_oidc_role`
+
+Creates an IAM role that can be assumed by GitHub Actions using GitHub's OIDC
+provider, provided that the workflow run is for the specified organisation,
+repository, and branch.
+
+- See
+  [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+  for details on how this works
+- See
+  [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+  for details on how this works with AWS
+
+> **Note**
+>
+> An OpenID Connect provider must exist in IAM with a URL of
+> `https://token.actions.githubusercontent.com`.
+
+## Usage
+
+```terraform
+# this exists at the account level, and is looked up by the module based on its URL
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  # the thumbprint should never change unless GitHub change their certificate chain
+  # see https://stackoverflow.com/questions/69247498 on how you can check the value
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "gha_access_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeInstances"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+module "gha_staging_role" {
+  source = "modules/github_oidc_role"
+
+  name_prefix_pascal_case = "${local.app_name_pascal_case}Staging"
+
+  github_org_name             = "ackama"
+  github_repo_name            = "my-repo"
+  allowed_oidc_subject_claims = ["ref:refs/heads/main"]
+
+  iam_policy_document_json = data.aws_iam_policy_document.gha_access_policy.json
+}
+
+output "gha_staging_role_arn" {
+  description = "The ARN to use for the role-to-assume input in GHA workflows"
+  value       = module.gha_staging_role.arn
+}
+```
+
+Sample workflow:
+
+```yaml
+# github.com/ackama/my-repo/blob/main/.github/workflows/describe-instances.yml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  describe-instances:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # this is the value of `terraform output gha_staging_role_arn`
+          role-to-assume: arn:aws:iam::1234567890:role/MyAppStagingGHARole
+          aws-region: ap-southeast-2
+      - run: aws ec2 describe-instances --query 'Reservations[].Instances[]'
+```
+
+You can also attach policies using the `aws_iam_role_policy_attachment` resource
+and the `role_name` output attribute:
+
+```terraform
+module "gha_role" {
+  source = "modules/github_oidc_role"
+
+  name_prefix_pascal_case = "${local.app_name_pascal_case}${local.env_name_pascal_case}"
+
+  github_org_name             = "ackama"
+  github_repo_name            = "my-repo"
+  allowed_oidc_subject_claims = ["ref:refs/heads/main"]
+}
+
+data "aws_iam_policy_document" "allow_uploading_to_s3" {
+  statement {
+    sid = "ListObjectsInBucket"
+
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      local.static_site_bucket_arn
+    ]
+  }
+
+  statement {
+    sid = "AllowObjectActions"
+
+    actions = [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${local.static_site_bucket_arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "gha_s3_access" {
+  description = "Read and write access to the static site hosting bucket"
+  name        = "${local.app_name_pascal_case}${local.env_name_pascal_case}StaticSiteBucketAccess"
+
+  policy = data.aws_iam_policy_document.allow_uploading_to_s3.json
+}
+
+resource "aws_iam_role_policy_attachment" "gha_s3_access" {
+  role       = module.gha_role.role_name
+  policy_arn = aws_iam_policy.gha_s3_access.arn
+}
+
+output "gha_role_arn" {
+  description = "The ARN to use for the role-to-assume input in GHA workflows"
+  value       = module.gha_role.arn
+}
+```
+
+Sample GHA workflow:
+
+```yaml
+# github.com/ackama/my-repo/blob/main/.github/workflows/deploy.yml
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-to-s3:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          # this is the value of `terraform output gha_role_arn`
+          role-to-assume: arn:aws:iam::1234567890:role/MyAppStagingGHARole
+          aws-region: ap-southeast-2
+      - run: aws s3 cp ./index.html s3://my-app-staging-bucket/
+```
+
+### Locking the role to certain Github Actions events (e.g. branch push, PR etc.)
+
+Github OIDC uses the "subject claim" string to lock down what kinds of Github
+Actions events are allowed to assume the role. We should endeavour to lock each
+role down as much as possible.
+
+```terraform
+module "gha_role" {
+  source = "modules/github_oidc_role"
+
+  # ...
+
+  allowed_oidc_subject_claims = [
+    # All subjects are automatically prefixed with the name of the org and the
+    # name of the repo e.g. `repo:ackama/some-app:`. This prefix cannot be
+    # removed. This means that `pull_request` in the list below becomes
+    # `repo:ackama/some-app:pull_request` in the eventual AWS IAM policy.
+    #
+    # See
+    # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims
+    # for details of all the possible subject claim filters you can construct.
+    #
+    # You should try to lock down the role as much as possible.
+    #
+    "ref:refs/heads/main",        # allow GA to assume this role on a branch push to 'main'
+    "ref:refs/heads/production",  # allow GA to assume this role on a branch push to 'production'
+    "pull_request"                # allow GA to assume this role on all pull requests
+    "ref:refs/tags/my-tag",       # allow GA to assume this role on a branches tagged with `my-tag`
+    "*",                          # allow GA to assume this role on any branch in response to any event (use with caution)
+  ]
+}
+```

--- a/modules/github_oidc_role/main.tf
+++ b/modules/github_oidc_role/main.tf
@@ -1,0 +1,54 @@
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  name_full_pascal_case = "${var.name_prefix_pascal_case}GHA"
+  oidc_subject_claims   = formatlist("repo:%s/%s:%s", var.github_org_name, var.github_repo_name, var.allowed_oidc_subject_claims)
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+      type        = "Federated"
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.oidc_subject_claims
+    }
+  }
+}
+
+resource "aws_iam_role" "main" {
+  name = "${local.name_full_pascal_case}Role"
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+
+  tags = {
+    Name = "${local.name_full_pascal_case}Role"
+  }
+}
+
+resource "aws_iam_role_policy" "main" {
+  count = length(var.iam_policy_document_json) > 0 ? 1 : 0
+
+  name = local.name_full_pascal_case
+  role = aws_iam_role.main.id
+
+  policy = var.iam_policy_document_json
+}

--- a/modules/github_oidc_role/outputs.tf
+++ b/modules/github_oidc_role/outputs.tf
@@ -1,0 +1,25 @@
+output "name_full_pascal_case" {
+  value = local.name_full_pascal_case
+}
+
+output "role_name" {
+  value = aws_iam_role.main.name
+}
+
+output "role_id" {
+  value = aws_iam_role.main.unique_id
+}
+
+output "arn" {
+  value = aws_iam_role.main.arn
+}
+
+output "oidc_subject_claims" {
+  description = <<-DESC
+    The value(s) that token.actions.githubusercontent.com:sub must equal when
+    trying to assume the role as a federated user.
+
+    Useful for debugging, to ensure that the value is correct.
+  DESC
+  value       = local.oidc_subject_claims
+}

--- a/modules/github_oidc_role/variables.tf
+++ b/modules/github_oidc_role/variables.tf
@@ -1,0 +1,48 @@
+variable "name_prefix_pascal_case" {
+  description = "Prefix that gets added to the start of any named resource created by this module"
+  type        = string
+}
+
+variable "github_org_name" {
+  description = <<-DESC
+    The name of the GitHub organisation that the GitHub Action run must be taking
+    place in to be able to assume this role.
+  DESC
+  type        = string
+}
+
+variable "github_repo_name" {
+  description = <<-DESC
+    The name of the GitHub repository that the GitHub Action run must be taking
+    place in to be able to assume this role.
+  DESC
+  type        = string
+}
+
+variable "allowed_oidc_subject_claims" {
+  description = <<-DESC
+    All subjects are automatically prefixed with the name of the org and the
+    name of the repo e.g. `repo:ackama/some-app:`. This prefix cannot be
+    removed. This means that `pull_request` in the list below becomes
+    `repo:ackama/some-app:pull_request` in the eventual AWS IAM policy.
+
+    See
+    https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims
+    for details of all the possible subject claim filters you can construct.
+
+    Example claims:
+
+    "ref:refs/heads/main"        # allow GA to assume this role on a branch push to 'main'
+    "ref:refs/heads/production"  # allow GA to assume this role on a branch push to 'production'
+    "pull_request"               # allow GA to assume this role on all pull requests
+    "ref:refs/tags/my-tag"       # allow GA to assume this role on a branches tagged with `my-tag`
+    "*"                          # allow GA to assume this role on any branch in response to any event (use with caution)
+  DESC
+  type        = list(string)
+}
+
+variable "iam_policy_document_json" {
+  description = "An IAM policy document in JSON form to create and attach to the role"
+  type        = string
+  default     = ""
+}

--- a/modules/github_oidc_role/versions.tf
+++ b/modules/github_oidc_role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/modules/readonly_bucket_access/README.md
+++ b/modules/readonly_bucket_access/README.md
@@ -1,0 +1,24 @@
+# `readonly_bucket_access`
+
+Creates an IAM user and keypair that has read-only access to a given S3 bucket.
+
+## Usage
+
+```terraform
+module "bucket_access" {
+  source = "modules/readonly_bucket_access"
+
+  user_name = "bucket-user"
+  bucket_name = "bucket"
+}
+
+output "aws_access_key_id" {
+  description = "The AWS access key ID for readonly bucket access"
+  value       = module.bucket_access.aws_access_key_id
+}
+
+output "aws_secret_access_key" {
+  description = "The AWS secret access key for readonly bucket access"
+  value       = module.bucket_access.aws_secret_access_key
+}
+```

--- a/modules/readonly_bucket_access/main.tf
+++ b/modules/readonly_bucket_access/main.tf
@@ -1,0 +1,31 @@
+
+resource "aws_iam_user" "access" {
+  name = var.user_name
+  tags = var.default_tags
+}
+
+resource "aws_iam_access_key" "access" {
+  user = aws_iam_user.access.name
+}
+
+resource "aws_s3_bucket_policy" "access" {
+  bucket = var.bucket_name
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "MediaBucket-Access",
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetObject",
+        ],
+        "Principal" : {
+          "AWS" : "${aws_iam_user.access.arn}"
+        },
+        "Resource" : [
+          "${var.bucket_name}/*",
+        ]
+      }
+    ]
+  })
+}

--- a/modules/readonly_bucket_access/main.tf
+++ b/modules/readonly_bucket_access/main.tf
@@ -23,7 +23,7 @@ resource "aws_s3_bucket_policy" "access" {
           "AWS" : "${aws_iam_user.access.arn}"
         },
         "Resource" : [
-          "${var.bucket_name}/*",
+          "arn:aws:s3:::${var.bucket_name}/*",
         ]
       }
     ]

--- a/modules/readonly_bucket_access/outputs.tf
+++ b/modules/readonly_bucket_access/outputs.tf
@@ -1,0 +1,9 @@
+output "aws_iam_access_key_id" {
+  value     = aws_iam_access_key.access.id
+  sensitive = true
+}
+
+output "aws_iam_secret_access_key" {
+  value     = aws_iam_access_key.access.secret
+  sensitive = true
+}

--- a/modules/readonly_bucket_access/variables.tf
+++ b/modules/readonly_bucket_access/variables.tf
@@ -1,0 +1,16 @@
+
+variable "default_tags" {
+  description = "A map of default tags that should be applied to the IAM user"
+  type        = map(string)
+  default     = {}
+}
+
+variable "bucket_name" {
+  description = "The name of the bucket to grant readonly access to"
+  type        = string
+}
+
+variable "user_name" {
+  description = "The name of the IAM user to create"
+  type        = string
+}

--- a/modules/readonly_bucket_access/versions.tf
+++ b/modules/readonly_bucket_access/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -55,7 +55,7 @@ module "github_oidc_role" {
   source = "../../modules/github_oidc_role"
 
   name_prefix_pascal_case     = local.app_name_pascal_case
-  github_org_name             = "odnzsl"
+  github_org_name             = "ODNZSL"
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Prerelease"]
   iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -1,9 +1,8 @@
-
 terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.13.0"
+      version = "~> 4.13"
     }
   }
 
@@ -16,6 +15,10 @@ terraform {
 
 provider "aws" {
   region = "ap-southeast-2"
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 locals {

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -46,9 +46,9 @@ data "aws_iam_policy_document" "write_only_access" {
 
 
 module "bucket_access" {
-  source       = "../../modules/readonly_bucket_access"
-  user_name    = "${local.app_name_pascal_case}User"
-  bucket_name  = "nzsl-signbank-media-uat"
+  source      = "../../modules/readonly_bucket_access"
+  user_name   = "${local.app_name_pascal_case}User"
+  bucket_name = "nzsl-signbank-media-uat"
 }
 
 module "github_oidc_role" {

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -47,7 +47,6 @@ data "aws_iam_policy_document" "write_only_access" {
 
 module "bucket_access" {
   source       = "../../modules/readonly_bucket_access"
-  default_tags = local.default_tags
   user_name    = "${local.app_name_pascal_case}User"
   bucket_name  = "nzsl-signbank-media-uat"
 }

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -28,6 +28,20 @@ locals {
   }
 }
 
+data "aws_iam_policy_document" "write_only_access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::nzsl-signbank-media-uat/dictionary-exports/nzsl.db"
+    ]
+  }
+}
+
+
 module "bucket_access" {
   source       = "../../modules/readonly_bucket_access"
   default_tags = local.default_tags
@@ -42,6 +56,7 @@ module "github_oidc_role" {
   github_org_name             = "odnzsl"
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Prerelease"]
+  iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json
 }
 
 output "aws_access_key_id" {

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -1,0 +1,57 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.13.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-prerelease.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+}
+
+locals {
+  app_name_pascal_case = "NZSLDictionaryScriptsPrereleaseDeployment"
+  default_tags = {
+    Environment      = "Prerelease"
+    Client           = "DSRU"
+    Project          = "NZSL Dictionary Scripts"
+    ProvisioningTool = "Terraform"
+  }
+}
+
+module "bucket_access" {
+  source       = "../../modules/readonly_bucket_access"
+  default_tags = local.default_tags
+  user_name    = "${local.app_name_pascal_case}User"
+  bucket_name  = "nzsl-signbank-media-uat"
+}
+
+module "github_oidc_role" {
+  source = "../../modules/github_oidc_role"
+
+  name_prefix_pascal_case     = local.app_name_pascal_case
+  github_org_name             = "odnzsl"
+  github_repo_name            = "nzsl-dictionary-scripts"
+  allowed_oidc_subject_claims = ["environment:Prerelease"]
+}
+
+output "aws_access_key_id" {
+  description = "The AWS access key ID for readonly bucket access"
+  value       = module.bucket_access.aws_iam_access_key_id
+  sensitive   = true
+}
+
+output "aws_secret_access_key" {
+  description = "The AWS secret access key for readonly bucket access"
+  value       = module.bucket_access.aws_iam_secret_access_key
+  sensitive   = true
+}

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -13,11 +13,13 @@ terraform {
   }
 }
 
+provider "aws" {
   region = "ap-southeast-2"
 
   default_tags {
     tags = local.default_tags
   }
+}
 
 locals {
   app_name_pascal_case = "NZSLDictionaryScriptsProductionDeployment"
@@ -44,7 +46,6 @@ data "aws_iam_policy_document" "write_only_access" {
 
 module "bucket_access" {
   source       = "../../modules/readonly_bucket_access"
-  default_tags = local.default_tags
   user_name    = "${local.app_name_pascal_case}User"
   bucket_name  = "nzsl-signbank-media-production"
 }

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -53,7 +53,7 @@ module "github_oidc_role" {
   source = "../../modules/github_oidc_role"
 
   name_prefix_pascal_case     = local.app_name_pascal_case
-  github_org_name             = "odnzsl"
+  github_org_name             = "ODNZSL"
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Production"]
   iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -45,9 +45,9 @@ data "aws_iam_policy_document" "write_only_access" {
 }
 
 module "bucket_access" {
-  source       = "../../modules/readonly_bucket_access"
-  user_name    = "${local.app_name_pascal_case}User"
-  bucket_name  = "nzsl-signbank-media-production"
+  source      = "../../modules/readonly_bucket_access"
+  user_name   = "${local.app_name_pascal_case}User"
+  bucket_name = "nzsl-signbank-media-production"
 }
 
 module "github_oidc_role" {

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -1,9 +1,8 @@
-
 terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.13.0"
+      version = "~> 4.13"
     }
   }
 
@@ -14,9 +13,11 @@ terraform {
   }
 }
 
-provider "aws" {
   region = "ap-southeast-2"
-}
+
+  default_tags {
+    tags = local.default_tags
+  }
 
 locals {
   app_name_pascal_case = "NZSLDictionaryScriptsProductionDeployment"

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -28,6 +28,19 @@ locals {
   }
 }
 
+data "aws_iam_policy_document" "write_only_access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/nzsl.db"
+    ]
+  }
+}
+
 module "bucket_access" {
   source       = "../../modules/readonly_bucket_access"
   default_tags = local.default_tags
@@ -42,6 +55,7 @@ module "github_oidc_role" {
   github_org_name             = "odnzsl"
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Production"]
+  iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json
 }
 
 output "aws_access_key_id" {

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -1,0 +1,57 @@
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.13.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-production.tfstate"
+  }
+}
+
+provider "aws" {
+  region = "ap-southeast-2"
+}
+
+locals {
+  app_name_pascal_case = "NZSLDictionaryScriptsProductionDeployment"
+  default_tags = {
+    Environment      = "Production"
+    Client           = "DSRU"
+    Project          = "NZSL Dictionary Scripts"
+    ProvisioningTool = "Terraform"
+  }
+}
+
+module "bucket_access" {
+  source       = "../../modules/readonly_bucket_access"
+  default_tags = local.default_tags
+  user_name    = "${local.app_name_pascal_case}User"
+  bucket_name  = "nzsl-signbank-media-production"
+}
+
+module "github_oidc_role" {
+  source = "../../modules/github_oidc_role"
+
+  name_prefix_pascal_case     = local.app_name_pascal_case
+  github_org_name             = "odnzsl"
+  github_repo_name            = "nzsl-dictionary-scripts"
+  allowed_oidc_subject_claims = ["environment:Production"]
+}
+
+output "aws_access_key_id" {
+  description = "The AWS access key ID for readonly bucket access"
+  value       = module.bucket_access.aws_iam_access_key_id
+  sensitive   = true
+}
+
+output "aws_secret_access_key" {
+  description = "The AWS secret access key for readonly bucket access"
+  value       = module.bucket_access.aws_iam_secret_access_key
+  sensitive   = true
+}

--- a/signbank/env-production/main.tf
+++ b/signbank/env-production/main.tf
@@ -24,12 +24,12 @@ terraform {
 }
 
 variable "default_tags" {
-  type = map
+  type        = map(any)
   description = "Common tags applied to all AWS resources"
   default = {
-    Environment = "production"
-    Client = "DSRU"
-    Project = "NZSL Signbank"
+    Environment      = "production"
+    Client           = "DSRU"
+    Project          = "NZSL Signbank"
     ProvisioningTool = "Terraform"
   }
 }
@@ -66,8 +66,8 @@ resource "heroku_app" "app" {
 
   config_vars = {
     "AWS_STORAGE_BUCKET_NAME" = aws_s3_bucket.media.id,
-    "ALLOWED_HOSTS" = "signbank.${data.cloudflare_zone.root.name}"
-    "DJANGO_SETTINGS_MODULE" = "signbank.settings.production"
+    "ALLOWED_HOSTS"           = "signbank.${data.cloudflare_zone.root.name}"
+    "DJANGO_SETTINGS_MODULE"  = "signbank.settings.production"
   }
 
   sensitive_config_vars = {
@@ -102,7 +102,7 @@ resource "heroku_addon" "database" {
 
 resource "aws_s3_bucket" "media" {
   bucket = "nzsl-signbank-media-production"
-  tags = var.default_tags
+  tags   = var.default_tags
 }
 
 resource "aws_s3_bucket_acl" "media" {

--- a/signbank/env-uat/main.tf
+++ b/signbank/env-uat/main.tf
@@ -24,12 +24,12 @@ terraform {
 }
 
 variable "default_tags" {
-  type = map
+  type        = map(any)
   description = "Common tags applied to all AWS resources"
   default = {
-    Environment = "uat"
-    Client = "DSRU"
-    Project = "NZSL Signbank"
+    Environment      = "uat"
+    Client           = "DSRU"
+    Project          = "NZSL Signbank"
     ProvisioningTool = "Terraform"
   }
 }
@@ -100,7 +100,7 @@ resource "heroku_addon" "database" {
 
 resource "aws_s3_bucket" "media" {
   bucket = "nzsl-signbank-media-uat"
-  tags = var.default_tags
+  tags   = var.default_tags
 }
 
 resource "aws_s3_bucket_acl" "media" {


### PR DESCRIPTION
This pull request provisions new resources for use by the Github Actions workflows in github.com/odnzsl/nzsl-dictionary-scripts and directly by github.com/odnzsl/nzsl-online and github.com/ackama/nzsl-share, specifically:

* A key-constrained write-only access role that allows an exported database (either prerelease or prod) to be written to the media S3 bucket with a custom ACL. This role uses OIDC - only the nzsl-dictionary-scripts repo in the correct environment can assume this role. We prefer this approach because there are no static keys required.
* An IAM access key that allows read-only access to the media bucket. This keypair will be used by nzsl-online and nzsl-share to generate presigned URLs to access the exported dictionary file and media files respectively. 

To provision these resources, I added in a couple of terraform modules - one from the Ackama standard terraform module repository, and one extracted from the prerelease env, to cut down on replication between prerelease and production.

I have not yet applied this configuration, but I have verified that a plan succeeds. I'm keen to get 👀 on this before I create any infrastructure.