### PR TITLE
Clean up permissions and attach policies via IAM rather than bucket 

### DIFF
--- a/modules/readonly_bucket_access/main.tf
+++ b/modules/readonly_bucket_access/main.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket_policy" "access" {
     "Version" : "2012-10-17",
     "Statement" : [
       {
-        "Sid" : "MediaBucket-Access",
+        "Sid" : "${var.user_name}ReadonlyBucketAccess",
         "Effect" : "Allow",
         "Action" : [
           "s3:GetObject",

--- a/modules/readonly_bucket_access/main.tf
+++ b/modules/readonly_bucket_access/main.tf
@@ -8,8 +8,10 @@ resource "aws_iam_access_key" "access" {
   user = aws_iam_user.access.name
 }
 
-resource "aws_s3_bucket_policy" "access" {
-  bucket = var.bucket_name
+resource "aws_iam_policy" "access" {
+  name        = "${var.user_name}_readonly_bucket_access_policy"
+  description = "Allows read-only access to the S3 bucket"
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -17,15 +19,17 @@ resource "aws_s3_bucket_policy" "access" {
         "Sid" : "${var.user_name}ReadonlyBucketAccess",
         "Effect" : "Allow",
         "Action" : [
-          "s3:GetObject",
+          "s3:GetObject"
         ],
-        "Principal" : {
-          "AWS" : "${aws_iam_user.access.arn}"
-        },
         "Resource" : [
-          "arn:aws:s3:::${var.bucket_name}/*",
+          "arn:aws:s3:::${var.bucket_name}/*"
         ]
       }
     ]
   })
+}
+
+resource "aws_iam_user_policy_attachment" "access" {
+  user       = aws_iam_user.access.name
+  policy_arn = aws_iam_policy.access.arn
 }

--- a/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "write_only_access" {
       "s3:PutObjectAcl"
     ]
     resources = [
-      "arn:aws:s3:::nzsl-signbank-media-uat/dictionary-exports/nzsl.db"
+      "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/prerelease/nzsl.db"
     ]
   }
 }
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "write_only_access" {
 module "bucket_access" {
   source      = "../../modules/readonly_bucket_access"
   user_name   = "${local.app_name_pascal_case}User"
-  bucket_name = "nzsl-signbank-media-uat"
+  bucket_name = "nzsl-signbank-media-production"
 }
 
 module "github_oidc_role" {

--- a/nzsl-dictionary-scripts/env-production/main.tf
+++ b/nzsl-dictionary-scripts/env-production/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "write_only_access" {
       "s3:PutObjectAcl"
     ]
     resources = [
-      "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/nzsl.db"
+      "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/production/nzsl.db"
     ]
   }
 }

--- a/signbank/env-production/main.tf
+++ b/signbank/env-production/main.tf
@@ -76,7 +76,7 @@ resource "heroku_app" "app" {
   }
 
   organization {
-    name = "ackama"
+    name = "nzsl"
   }
 }
 
@@ -97,7 +97,7 @@ resource "cloudflare_record" "app" {
 # Create a database, and configure the app to use it
 resource "heroku_addon" "database" {
   app_id = heroku_app.app.id
-  plan   = "heroku-postgresql:hobby-basic"
+  plan   = "heroku-postgresql:basic"
 }
 
 resource "aws_s3_bucket" "media" {

--- a/signbank/env-production/main.tf
+++ b/signbank/env-production/main.tf
@@ -145,13 +145,20 @@ resource "null_resource" "schedule_backups" {
   }
 }
 
-resource "aws_s3_bucket_policy" "media" {
-  bucket = aws_s3_bucket.media.id
+resource "aws_iam_user_policy_attachment" "media" {
+  user       = aws_iam_user.app.name
+  policy_arn = aws_iam_policy.media.arn
+}
+
+resource "aws_iam_policy" "media" {
+  name        = "SignbankProductionMediaBucketAccessPolicy"
+  description = "IAM policy for accessing the media bucket"
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
       {
-        "Sid" : "MediaBucket-Access",
+        "Sid" : "SignbankProductionMediaBucketAccess",
         "Effect" : "Allow",
         "Action" : [
           "s3:PutObject",
@@ -160,11 +167,8 @@ resource "aws_s3_bucket_policy" "media" {
           "s3:DeleteObject",
           "s3:PutObjectAcl"
         ],
-        "Principal" : {
-          "AWS" : "${aws_iam_user.app.arn}"
-        },
         "Resource" : [
-          "${aws_s3_bucket.media.arn}/*",
+          "${aws_s3_bucket.media.arn}/*"
         ]
       }
     ]

--- a/signbank/env-uat/main.tf
+++ b/signbank/env-uat/main.tf
@@ -117,13 +117,20 @@ resource "aws_iam_access_key" "app" {
   user = aws_iam_user.app.name
 }
 
-resource "aws_s3_bucket_policy" "media" {
-  bucket = aws_s3_bucket.media.id
+resource "aws_iam_user_policy_attachment" "media" {
+  user       = aws_iam_user.app.name
+  policy_arn = aws_iam_policy.media.arn
+}
+
+resource "aws_iam_policy" "media" {
+  name        = "SignbankUATMediaBucketAccessPolicy"
+  description = "IAM policy for accessing the media bucket"
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
       {
-        "Sid" : "MediaBucket-Access",
+        "Sid" : "SignbankUATMediaBucketAccess",
         "Effect" : "Allow",
         "Action" : [
           "s3:PutObject",
@@ -132,11 +139,8 @@ resource "aws_s3_bucket_policy" "media" {
           "s3:DeleteObject",
           "s3:PutObjectAcl"
         ],
-        "Principal" : {
-          "AWS" : "${aws_iam_user.app.arn}"
-        },
         "Resource" : [
-          "${aws_s3_bucket.media.arn}/*",
+          "${aws_s3_bucket.media.arn}/*"
         ]
       }
     ]

--- a/signbank/env-uat/main.tf
+++ b/signbank/env-uat/main.tf
@@ -74,7 +74,7 @@ resource "heroku_app" "app" {
   }
 
   organization {
-    name = "ackama"
+    name = "nzsl"
   }
 }
 
@@ -95,7 +95,7 @@ resource "cloudflare_record" "app" {
 # Create a database, and configure the app to use it
 resource "heroku_addon" "database" {
   app_id = heroku_app.app.id
-  plan   = "heroku-postgresql:hobby-basic"
+  plan   = "heroku-postgresql:basic"
 }
 
 resource "aws_s3_bucket" "media" {


### PR DESCRIPTION
This pull request addresses an issue that I introduced by using bucket policies in multiple environments/apps pointing at the same bucket, causing the bucket policy to be overwritten depending on which app/env was applied last.

Rather than using bucket policies, this PR changes to use a normal IAM policy, attached to the user or role that requires that access. It also updates the bucket that the prerelease environment that nzsl-dictionary-scripts points to, since the prerelease data is still from Signbank production, it's just a broader scope than the 'production' data release.

While applying these configurations, I also made some changes to bring the Heroku application configuration into line with some changes made recently - most significantly, moving them to a dedicated Heroku team.

(These changes have already been applied)