### PR TITLE
fix: update Heroku database addons to reflect recent manual changes

### DIFF
--- a/terraform/environments/signbank/env-production/main.tf
+++ b/terraform/environments/signbank/env-production/main.tf
@@ -97,7 +97,7 @@ resource "cloudflare_record" "app" {
 # Create a database, and configure the app to use it
 resource "heroku_addon" "database" {
   app_id = heroku_app.app.id
-  plan   = "heroku-postgresql:basic"
+  plan   = "heroku-postgresql:essential-0"
 }
 
 resource "aws_s3_bucket" "media" {
@@ -174,4 +174,3 @@ resource "aws_iam_policy" "media" {
     ]
   })
 }
-

--- a/terraform/environments/signbank/env-uat/main.tf
+++ b/terraform/environments/signbank/env-uat/main.tf
@@ -95,7 +95,7 @@ resource "cloudflare_record" "app" {
 # Create a database, and configure the app to use it
 resource "heroku_addon" "database" {
   app_id = heroku_app.app.id
-  plan   = "heroku-postgresql:basic"
+  plan   = "heroku-postgresql:essential-0"
 }
 
 resource "aws_s3_bucket" "media" {
@@ -146,4 +146,3 @@ resource "aws_iam_policy" "media" {
     ]
   })
 }
-


### PR DESCRIPTION
The old plans have been deprecated in favor of the `essential` plans which we manually moved to a few months back