### PR TITLE
feat: setup DNS for `learnnzsl.nz` domain

### DIFF
--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -223,6 +223,36 @@ resource "cloudflare_record" "www_learnnzsl_nz_cname" {
   ttl     = 1
 }
 
+import {
+  id = "zone/${data.cloudflare_zone.learnnzsl_nz.zone_id}/6f108065d50c48359061ba52ed949360"
+  to = cloudflare_ruleset.redirect_to_learn_nzsl_nz
+}
+
+resource "cloudflare_ruleset" "redirect_to_learn_nzsl_nz" {
+  zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
+  name    = "default"
+  kind    = "zone"
+  phase   = "http_request_dynamic_redirect"
+
+  rules {
+    description = "Redirect to learn.nzsl.nz"
+    action      = "redirect"
+    enabled     = true
+    expression  = "true"
+
+    action_parameters {
+      from_value {
+        preserve_query_string = true
+        status_code           = 302
+
+        target_url {
+          expression = "concat(\"https://learn.nzsl.nz\",http.request.uri.path)"
+        }
+      }
+    }
+  }
+}
+
 ################################################################################
 # Cloudfront distribution
 ################################################################################

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -186,7 +186,8 @@ module "cert" {
   primary_domain_name     = "learn.nzsl.nz"
   primary_domain_zone_id  = data.cloudflare_zone.root.id
   secondary_domains       = {
-    "learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id
+    "learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id,
+    "www.learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id
   }
   name_prefix_pascal_case = "${local.app_name_pascal_case}CloudFront"
 
@@ -207,6 +208,15 @@ resource "cloudflare_record" "app" {
 resource "cloudflare_record" "app2" {
   zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
   name    = "@"
+  value   = aws_cloudfront_distribution.cdn.domain_name
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
+resource "cloudflare_record" "app3" {
+  zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
+  name    = "www"
   value   = aws_cloudfront_distribution.cdn.domain_name
   type    = "CNAME"
   proxied = true
@@ -240,7 +250,8 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   aliases = [
     "learn.nzsl.nz",
-    "learnnzsl.nz"
+    "learnnzsl.nz",
+    "www.learnnzsl.nz"
   ]
 
   default_cache_behavior {

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -223,11 +223,6 @@ resource "cloudflare_record" "www_learnnzsl_nz_cname" {
   ttl     = 1
 }
 
-import {
-  id = "zone/${data.cloudflare_zone.learnnzsl_nz.zone_id}/6f108065d50c48359061ba52ed949360"
-  to = cloudflare_ruleset.redirect_to_learn_nzsl_nz
-}
-
 resource "cloudflare_ruleset" "redirect_to_learn_nzsl_nz" {
   zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
   name    = "default"

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -196,11 +196,6 @@ module "cert" {
   }
 }
 
-moved {
-  from = cloudflare_record.app
-  to = cloudflare_record.learn_nzsl_nz_cname
-}
-
 resource "cloudflare_record" "learn_nzsl_nz_cname" {
   zone_id = data.cloudflare_zone.nzsl_nz.zone_id
   name    = "learn"
@@ -210,11 +205,6 @@ resource "cloudflare_record" "learn_nzsl_nz_cname" {
   ttl     = 1
 }
 
-moved {
-  from = cloudflare_record.app2
-  to = cloudflare_record.learnnzsl_nz_cname
-}
-
 resource "cloudflare_record" "learnnzsl_nz_cname" {
   zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
   name    = "@"
@@ -222,11 +212,6 @@ resource "cloudflare_record" "learnnzsl_nz_cname" {
   type    = "CNAME"
   proxied = true
   ttl     = 1
-}
-
-moved {
-  from = cloudflare_record.app3
-  to = cloudflare_record.www_learnnzsl_nz_cname
 }
 
 resource "cloudflare_record" "www_learnnzsl_nz_cname" {

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -172,7 +172,7 @@ resource "aws_s3_bucket_policy" "hosting" {
 # DNS zone and records
 ################################################################################
 
-data "cloudflare_zone" "root" {
+data "cloudflare_zone" "nzsl_nz" {
   name = "nzsl.nz"
 }
 
@@ -184,7 +184,7 @@ module "cert" {
   source = "../../../modules/acm/validated_with_cloudflare"
 
   primary_domain_name     = "learn.nzsl.nz"
-  primary_domain_zone_id  = data.cloudflare_zone.root.id
+  primary_domain_zone_id  = data.cloudflare_zone.nzsl_nz.id
   secondary_domains       = {
     "learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id,
     "www.learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id
@@ -196,8 +196,13 @@ module "cert" {
   }
 }
 
-resource "cloudflare_record" "app" {
-  zone_id = data.cloudflare_zone.root.zone_id
+moved {
+  from = cloudflare_record.app
+  to = cloudflare_record.learn_nzsl_nz_cname
+}
+
+resource "cloudflare_record" "learn_nzsl_nz_cname" {
+  zone_id = data.cloudflare_zone.nzsl_nz.zone_id
   name    = "learn"
   value   = aws_cloudfront_distribution.cdn.domain_name
   type    = "CNAME"
@@ -205,7 +210,12 @@ resource "cloudflare_record" "app" {
   ttl     = 1
 }
 
-resource "cloudflare_record" "app2" {
+moved {
+  from = cloudflare_record.app2
+  to = cloudflare_record.learnnzsl_nz_cname
+}
+
+resource "cloudflare_record" "learnnzsl_nz_cname" {
   zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
   name    = "@"
   value   = aws_cloudfront_distribution.cdn.domain_name
@@ -214,7 +224,12 @@ resource "cloudflare_record" "app2" {
   ttl     = 1
 }
 
-resource "cloudflare_record" "app3" {
+moved {
+  from = cloudflare_record.app3
+  to = cloudflare_record.www_learnnzsl_nz_cname
+}
+
+resource "cloudflare_record" "www_learnnzsl_nz_cname" {
   zone_id = data.cloudflare_zone.learnnzsl_nz.zone_id
   name    = "www"
   value   = aws_cloudfront_distribution.cdn.domain_name


### PR DESCRIPTION
We've gotten the learnnzsl.nz domain moved over to CloudFlare so we can now restore it to working order - since we've already got `learn.nzsl.nz` setup and there's a long-term goal of moving things over to subdomains of `nzsl.nz`, rather than move this app back to the original `learnnzsl.nz` domain I've setup a redirect to the new home.