### PR TITLE
refactor: Split versions and outputs into their own files

### DIFF
--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -161,11 +161,11 @@ data "cloudflare_zone" "learnnzsl_nz" {
 module "cert" {
   source = "../../../modules/acm/validated_with_cloudflare"
 
-  primary_domain_name     = "learn.nzsl.nz"
-  primary_domain_zone_id  = data.cloudflare_zone.nzsl_nz.id
-  secondary_domains       = {
-    "learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id,
-    "www.learnnzsl.nz": data.cloudflare_zone.learnnzsl_nz.id
+  primary_domain_name    = "learn.nzsl.nz"
+  primary_domain_zone_id = data.cloudflare_zone.nzsl_nz.id
+  secondary_domains = {
+    "learnnzsl.nz" : data.cloudflare_zone.learnnzsl_nz.id,
+    "www.learnnzsl.nz" : data.cloudflare_zone.learnnzsl_nz.id
   }
   name_prefix_pascal_case = "${local.app_name_pascal_case}CloudFront"
 

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -1,25 +1,3 @@
-terraform {
-  required_version = "~> 1.9.0"
-
-  backend "s3" {
-    region = "ap-southeast-2"
-    bucket = "nzsl-infrastructure-terraform-state"
-    key    = "learnnzsl-production"
-  }
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 3.0"
-    }
-  }
-}
-
 provider "aws" {
   region = "ap-southeast-2"
 

--- a/terraform/environments/learn/env-production/main.tf
+++ b/terraform/environments/learn/env-production/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    region = "ap-southeast-2"
+    bucket = "nzsl-infrastructure-terraform-state"
+    key    = "learnnzsl-production"
+  }
+}
+
 provider "aws" {
   region = "ap-southeast-2"
 

--- a/terraform/environments/learn/env-production/versions.tf
+++ b/terraform/environments/learn/env-production/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  backend "s3" {
+    region = "ap-southeast-2"
+    bucket = "nzsl-infrastructure-terraform-state"
+    key    = "learnnzsl-production"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/environments/learn/env-production/versions.tf
+++ b/terraform/environments/learn/env-production/versions.tf
@@ -1,12 +1,6 @@
 terraform {
   required_version = "~> 1.9.0"
 
-  backend "s3" {
-    region = "ap-southeast-2"
-    bucket = "nzsl-infrastructure-terraform-state"
-    key    = "learnnzsl-production"
-  }
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/.terraform.lock.hcl
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.13"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-global.tfstate"
+  }
+}
+
 provider "aws" {
   region = "ap-southeast-2"
 

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/outputs.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "The name of the S3 bucket for dictionary exports"
+  value       = aws_s3_bucket.dictionary_data.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket for dictionary exports"
+  value       = aws_s3_bucket.dictionary_data.arn
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.13"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-global.tfstate"
+  }
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/versions.tf
@@ -7,10 +7,4 @@ terraform {
       version = "~> 4.13"
     }
   }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "nzsl-dictionary-scripts/env-global.tfstate"
-  }
 }

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -1,20 +1,3 @@
-terraform {
-  required_version = "~> 1.9.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.13"
-    }
-  }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "nzsl-dictionary-scripts/env-prerelease.tfstate"
-  }
-}
-
 provider "aws" {
   region = "ap-southeast-2"
 
@@ -61,16 +44,4 @@ module "github_oidc_role" {
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Prerelease"]
   iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json
-}
-
-output "aws_access_key_id" {
-  description = "The AWS access key ID for readonly bucket access"
-  value       = module.bucket_access.aws_iam_access_key_id
-  sensitive   = true
-}
-
-output "aws_secret_access_key" {
-  description = "The AWS secret access key for readonly bucket access"
-  value       = module.bucket_access.aws_iam_secret_access_key
-  sensitive   = true
 }

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-prerelease.tfstate"
+  }
+}
+
 provider "aws" {
   region = "ap-southeast-2"
 

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/outputs.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/outputs.tf
@@ -1,0 +1,11 @@
+output "aws_access_key_id" {
+  description = "The AWS access key ID for readonly bucket access"
+  value       = module.bucket_access.aws_iam_access_key_id
+  sensitive   = true
+}
+
+output "aws_secret_access_key" {
+  description = "The AWS secret access key for readonly bucket access"
+  value       = module.bucket_access.aws_iam_secret_access_key
+  sensitive   = true
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/versions.tf
@@ -7,10 +7,4 @@ terraform {
       version = "~> 4.13"
     }
   }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "nzsl-dictionary-scripts/env-prerelease.tfstate"
-  }
 }

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.13"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-prerelease.tfstate"
+  }
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
@@ -1,20 +1,3 @@
-terraform {
-  required_version = "~> 1.9.0"
-
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.13"
-    }
-  }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "nzsl-dictionary-scripts/env-production.tfstate"
-  }
-}
-
 provider "aws" {
   region = "ap-southeast-2"
 
@@ -60,16 +43,4 @@ module "github_oidc_role" {
   github_repo_name            = "nzsl-dictionary-scripts"
   allowed_oidc_subject_claims = ["environment:Production"]
   iam_policy_document_json    = data.aws_iam_policy_document.write_only_access.json
-}
-
-output "aws_access_key_id" {
-  description = "The AWS access key ID for readonly bucket access"
-  value       = module.bucket_access.aws_iam_access_key_id
-  sensitive   = true
-}
-
-output "aws_secret_access_key" {
-  description = "The AWS secret access key for readonly bucket access"
-  value       = module.bucket_access.aws_iam_secret_access_key
-  sensitive   = true
 }

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-production.tfstate"
+  }
+}
+
 provider "aws" {
   region = "ap-southeast-2"
 

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/outputs.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/outputs.tf
@@ -1,0 +1,11 @@
+output "aws_access_key_id" {
+  description = "The AWS access key ID for readonly bucket access"
+  value       = module.bucket_access.aws_iam_access_key_id
+  sensitive   = true
+}
+
+output "aws_secret_access_key" {
+  description = "The AWS secret access key for readonly bucket access"
+  value       = module.bucket_access.aws_iam_secret_access_key
+  sensitive   = true
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/versions.tf
@@ -7,10 +7,4 @@ terraform {
       version = "~> 4.13"
     }
   }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "nzsl-dictionary-scripts/env-production.tfstate"
-  }
 }

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/versions.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.13"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "nzsl-dictionary-scripts/env-production.tfstate"
+  }
+}

--- a/terraform/environments/signbank/env-production/main.tf
+++ b/terraform/environments/signbank/env-production/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "signbank/production.tfstate"
+  }
+}
+
 variable "default_tags" {
   type        = map(any)
   description = "Common tags applied to all AWS resources"

--- a/terraform/environments/signbank/env-production/main.tf
+++ b/terraform/environments/signbank/env-production/main.tf
@@ -1,29 +1,3 @@
-terraform {
-  required_version = "~> 1.9.0"
-
-  required_providers {
-    heroku = {
-      source  = "heroku/heroku"
-      version = "5.0.2"
-    }
-    aws = {
-      source  = "hashicorp/aws"
-      version = "4.13.0"
-    }
-
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 3.0"
-    }
-  }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "signbank/production.tfstate"
-  }
-}
-
 variable "default_tags" {
   type        = map(any)
   description = "Common tags applied to all AWS resources"

--- a/terraform/environments/signbank/env-production/versions.tf
+++ b/terraform/environments/signbank/env-production/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  required_providers {
+    heroku = {
+      source  = "heroku/heroku"
+      version = "5.0.2"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.13.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "signbank/production.tfstate"
+  }
+}

--- a/terraform/environments/signbank/env-production/versions.tf
+++ b/terraform/environments/signbank/env-production/versions.tf
@@ -16,10 +16,4 @@ terraform {
       version = "~> 3.0"
     }
   }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "signbank/production.tfstate"
-  }
 }

--- a/terraform/environments/signbank/env-uat/main.tf
+++ b/terraform/environments/signbank/env-uat/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "signbank/uat.tfstate"
+  }
+}
+
 variable "default_tags" {
   type        = map(any)
   description = "Common tags applied to all AWS resources"

--- a/terraform/environments/signbank/env-uat/main.tf
+++ b/terraform/environments/signbank/env-uat/main.tf
@@ -1,29 +1,3 @@
-terraform {
-  required_version = "~> 1.9.0"
-
-  required_providers {
-    heroku = {
-      source  = "heroku/heroku"
-      version = "5.0.2"
-    }
-    aws = {
-      source  = "hashicorp/aws"
-      version = "4.13.0"
-    }
-
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 3.0"
-    }
-  }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "signbank/uat.tfstate"
-  }
-}
-
 variable "default_tags" {
   type        = map(any)
   description = "Common tags applied to all AWS resources"

--- a/terraform/environments/signbank/env-uat/versions.tf
+++ b/terraform/environments/signbank/env-uat/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = "~> 1.9.0"
+
+  required_providers {
+    heroku = {
+      source  = "heroku/heroku"
+      version = "5.0.2"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.13.0"
+    }
+
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 3.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "nzsl-infrastructure-terraform-state"
+    region = "ap-southeast-2"
+    key    = "signbank/uat.tfstate"
+  }
+}

--- a/terraform/environments/signbank/env-uat/versions.tf
+++ b/terraform/environments/signbank/env-uat/versions.tf
@@ -16,10 +16,4 @@ terraform {
       version = "~> 3.0"
     }
   }
-
-  backend "s3" {
-    bucket = "nzsl-infrastructure-terraform-state"
-    region = "ap-southeast-2"
-    key    = "signbank/uat.tfstate"
-  }
 }


### PR DESCRIPTION
This pull request restructures the Terraform configuration files for several environments by moving the `terraform` block (including backend and provider requirements) from each environment's `main.tf` into a new dedicated `versions.tf` file, and outputs into a new dedicated `outputs.tf` file.

This change was originally proposed in #11, but was not really related to that change.