### PR TITLE
Enable limited public-read ACL access for production releases of dictionary data

### DIFF
--- a/terraform/environments/nzsl-dictionary-scripts/env-global/.terraform.lock.hcl
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.13"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "dictionary_data_bucket_access_policy" {
     }
 
     resources = [
-      "${aws_s3_bucket.dictionary_data.arn}/public/*"
+      "${aws_s3_bucket.dictionary_data.arn}/*/public/*"
     ]
   }
 

--- a/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-global/main.tf
@@ -21,13 +21,26 @@ resource "aws_s3_bucket" "dictionary_data" {
   bucket = local.bucket_name
 }
 
-# Block all public access
+# Enable ACLs on the bucket (required to set public-read ACLs on objects)
+# By default, newer S3 buckets use "BucketOwnerEnforced" which disables ACLs entirely.
+# Setting this to "BucketOwnerPreferred" allows ACLs to be set on objects while
+# defaulting to bucket owner ownership when no ACL is specified.
+resource "aws_s3_bucket_ownership_controls" "dictionary_data" {
+  bucket = aws_s3_bucket.dictionary_data.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# Allow public ACLs on individual objects while blocking public bucket policies
+# This is because some dictionary exports are publicly accessible, but everything should be private by default
 resource "aws_s3_bucket_public_access_block" "dictionary_data" {
   bucket = aws_s3_bucket.dictionary_data.id
 
-  block_public_acls       = true
+  block_public_acls       = false
   block_public_policy     = true
-  ignore_public_acls      = true
+  ignore_public_acls      = false
   restrict_public_buckets = true
 }
 

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -55,7 +55,6 @@ module "bucket_access" {
   source       = "../../../modules/readonly_bucket_access"
   user_name    = "${local.app_name_pascal_case}User"
   bucket_name  = local.bucket_name
-  default_tags = local.default_tags
 }
 
 module "github_oidc_role" {

--- a/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-prerelease/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "write_only_access" {
     ]
     resources = [
       # New dedicated bucket
-      "arn:aws:s3:::${local.bucket_name}/prerelease/*",
+      "arn:aws:s3:::${local.bucket_name}/dictionary-exports/prerelease/*",
 
       # Legacy bucket access (temporary during migration)
       "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/prerelease/*"

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
@@ -54,7 +54,6 @@ module "bucket_access" {
   source       = "../../../modules/readonly_bucket_access"
   user_name    = "${local.app_name_pascal_case}User"
   bucket_name  = local.bucket_name
-  default_tags = local.default_tags
 }
 
 module "github_oidc_role" {

--- a/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
+++ b/terraform/environments/nzsl-dictionary-scripts/env-production/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "write_only_access" {
     ]
     resources = [
       # New dedicated bucket
-      "arn:aws:s3:::${local.bucket_name}/production/*",
+      "arn:aws:s3:::${local.bucket_name}/dictionary-exports/public/*",
       # Legacy bucket access (temporary during migration)
       "arn:aws:s3:::nzsl-signbank-media-production/dictionary-exports/production/*"
     ]


### PR DESCRIPTION
I also considered a bucket policy, but I _think_ this is better, since it continues defaulting to a private ACL, so requires opting into publication, rather than it being inferred by a key prefix. @G-Rath you might have opinions on this?